### PR TITLE
Use a relative path to allow tests to run from within an IDE

### DIFF
--- a/aviso-server/admin/tests/test_cleaner.py
+++ b/aviso-server/admin/tests/test_cleaner.py
@@ -8,6 +8,7 @@
 
 import datetime
 import os
+from pathlib import Path
 
 import requests
 from aviso_admin import config, logger
@@ -16,7 +17,8 @@ from aviso_admin.utils import encode_to_str_base64
 
 
 def conf() -> config.Config:  # this automatically configure the logging
-    c = config.Config(conf_path="aviso-server/admin/tests/config.yaml")
+    here = Path(__file__).parent
+    c = config.Config(conf_path=str(Path(here / "config.yaml")))
     return c
 
 


### PR DESCRIPTION
Hi, I tried running that test from within my IDE, PyCharm, but it failed due to the configuration location used. Would it be possible to use relative paths, so that tests run on CI or IDE's like mine, please? This PR has a tentative fix :+1: (I was interested on running just this one test, so I didn't check the other tests to see if a similar fix would be useful there.)

Thanks!
-Bruno