### PR TITLE
Hotfix/ssl fix

### DIFF
--- a/aviso-server/monitoring/aviso_monitoring/config.py
+++ b/aviso-server/monitoring/aviso_monitoring/config.py
@@ -184,7 +184,7 @@ class Config:
         assert ar is not None, "aviso_rest_reporter has not been configured"
         assert ar.get("tlms") is not None, "aviso_rest_reporter tlms has not been configured"
         assert ar.get("enabled") is not None, "aviso_rest_reporter enabled has not been configured"
-        if type(ar["enabled"]) is str:
+        if isinstance(ar["enabled"], str):
             ar["enabled"] = ar["enabled"].casefold() == "true".casefold()
         assert ar.get("frequency") is not None, "aviso_rest_reporter frequency has not been configured"
         self._aviso_rest_reporter = ar
@@ -204,7 +204,7 @@ class Config:
         assert aa is not None, "aviso_auth_reporter has not been configured"
         assert aa.get("tlms") is not None, "aviso_auth_reporter tlms has not been configured"
         assert aa.get("enabled") is not None, "aviso_auth_reporter enabled has not been configured"
-        if type(aa["enabled"]) is str:
+        if isinstance(aa["enabled"], str):
             aa["enabled"] = aa["enabled"].casefold() == "true".casefold()
         assert aa.get("frequency") is not None, "aviso_auth_reporter frequency has not been configured"
         self._aviso_auth_reporter = aa
@@ -224,7 +224,7 @@ class Config:
         assert e is not None, "etcd_reporter has not been configured"
         assert e.get("tlms") is not None, "etcd_reporter tlms has not been configured"
         assert e.get("enabled") is not None, "etcd_reporter enabled has not been configured"
-        if type(e["enabled"]) is str:
+        if isinstance(e["enabled"], str):
             e["enabled"] = e["enabled"].casefold() == "true".casefold()
         assert e.get("frequency") is not None, "etcd_reporter frequency has not been configured"
         assert e.get("member_urls") is not None, "etcd_reporter member_urls has not been configured"
@@ -246,7 +246,7 @@ class Config:
         assert pr is not None, "prometheus_reporter has not been configured"
         assert pr.get("host") is not None, "prometheus_reporter host has not been configured"
         assert pr.get("enabled") is not None, "prometheus_reporter enabled has not been configured"
-        if type(pr["enabled"]) is str:
+        if isinstance(pr["enabled"], str):
             pr["enabled"] = pr["enabled"].casefold() == "true".casefold()
         assert pr.get("port") is not None, "prometheus_reporter port has not been configured"
         self._prometheus_reporter = pr
@@ -265,7 +265,8 @@ class Config:
         # verify is valid
         assert ksm is not None, "kube_state_metrics has not been configured"
         assert ksm.get("ssl_enabled") is not None, "kube_state_metrics ssl_enabled has not been configured"
-        assert ksm.get("token") is not None, "kube_state_metrics token has not been configured"
+        if ksm["ssl_enabled"]:
+            assert ksm.get("token") is not None, "kube_state_metrics token has not been configured"
         self._kube_state_metrics = ksm
 
     def __str__(self):

--- a/aviso-server/monitoring/aviso_monitoring/reporter/aviso_auth_reporter.py
+++ b/aviso-server/monitoring/aviso_monitoring/reporter/aviso_auth_reporter.py
@@ -202,9 +202,7 @@ class PodAvailable(AvisoAuthChecker):
 
     def metric(self):
         namespace = self.get_k8s_pod_namespace()
-        if namespace:
-            logger.info(f"The pod is running in the '{namespace}' namespace.")
-        else:
+        if not namespace:
             logger.warning("Could not determine the pod's namespace.")
             namespace = "aviso"
 

--- a/aviso-server/monitoring/aviso_monitoring/reporter/aviso_auth_reporter.py
+++ b/aviso-server/monitoring/aviso_monitoring/reporter/aviso_auth_reporter.py
@@ -201,7 +201,14 @@ class PodAvailable(AvisoAuthChecker):
         super().__init__(*args, **kwargs)
 
     def metric(self):
-        pattern = r'kube_deployment_status_replicas{namespace="aviso",deployment="aviso-auth-\w+"}'
+        namespace = self.get_k8s_pod_namespace()
+        if namespace:
+            logger.info(f"The pod is running in the '{namespace}' namespace.")
+        else:
+            logger.warning("Could not determine the pod's namespace.")
+            namespace = "aviso"
+
+        pattern = rf'kube_deployment_status_replicas{{namespace="{namespace}",deployment="aviso-auth-\w+"}}'
         # defaults
         status = 0
         message = "All pods available"
@@ -243,3 +250,30 @@ class PodAvailable(AvisoAuthChecker):
             m_status = {"name": self.metric_name, "status": 1, "message": "Metric could not be retrieved"}
         logger.debug(f"{self.metric_name} metric: {m_status}")
         return m_status
+
+    @staticmethod
+    def get_k8s_pod_namespace():
+        """
+        Retrieves the Kubernetes (k8s) namespace in which the current pod is running.
+
+        This function reads the namespace name from a file that Kubernetes automatically
+        mounts inside the pod. This file is typically located at:
+        '/var/run/secrets/kubernetes.io/serviceaccount/namespace'
+
+        Returns:
+            str: The namespace in which the pod is running. If the namespace cannot be determined
+                (e.g., the file doesn't exist or the pod is not running in a k8s environment),
+                the function returns None.
+        """
+        namespace_file = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+        try:
+            with open(namespace_file, "r") as file:
+                return file.read().strip()
+        except FileNotFoundError:
+            logger.error(f"Namespace file not found: {namespace_file}")
+        except IOError as e:
+            logger.error(f"I/O error occurred when reading namespace file: {e}")
+        except Exception as e:
+            logger.exception(f"Unexpected error occurred when reading namespace file: {e}")
+
+        return None

--- a/aviso-server/monitoring/aviso_monitoring/reporter/aviso_auth_reporter.py
+++ b/aviso-server/monitoring/aviso_monitoring/reporter/aviso_auth_reporter.py
@@ -198,7 +198,6 @@ class PodAvailable(AvisoAuthChecker):
         self.critical_t = kwargs["critical_t"]
         self.req_timeout = kwargs["req_timeout"]
         self.metric_server_url = kwargs["metric_server_url"]
-        self.opsview_reporter = OpsviewReporter()
         super().__init__(*args, **kwargs)
 
     def metric(self):
@@ -210,13 +209,13 @@ class PodAvailable(AvisoAuthChecker):
 
         # fetch the cluster metrics
         if self.metric_server_url:
-            metrics = self.opsview_reporter.retrieve_metrics([self.metric_server_url], self.req_timeout)[
+            metrics = OpsviewReporter.retrieve_metrics([self.metric_server_url], self.req_timeout)[
                 self.metric_server_url
             ]
             if metrics:
                 logger.debug(f"Processing tlm {self.metric_name}...")
 
-                av_pod = self.opsview_reporter.read_from_metrics(metrics, pattern)
+                av_pod = OpsviewReporter.read_from_metrics(metrics, pattern)
                 if av_pod:
                     av_pod = int(av_pod)
                     if av_pod <= self.critical_t:

--- a/aviso-server/monitoring/aviso_monitoring/reporter/aviso_auth_reporter.py
+++ b/aviso-server/monitoring/aviso_monitoring/reporter/aviso_auth_reporter.py
@@ -198,6 +198,7 @@ class PodAvailable(AvisoAuthChecker):
         self.critical_t = kwargs["critical_t"]
         self.req_timeout = kwargs["req_timeout"]
         self.metric_server_url = kwargs["metric_server_url"]
+        self.opsview_reporter = OpsviewReporter()
         super().__init__(*args, **kwargs)
 
     def metric(self):
@@ -209,13 +210,13 @@ class PodAvailable(AvisoAuthChecker):
 
         # fetch the cluster metrics
         if self.metric_server_url:
-            metrics = OpsviewReporter.retrieve_metrics([self.metric_server_url], self.req_timeout)[
+            metrics = self.opsview_reporter.retrieve_metrics([self.metric_server_url], self.req_timeout)[
                 self.metric_server_url
             ]
             if metrics:
                 logger.debug(f"Processing tlm {self.metric_name}...")
 
-                av_pod = OpsviewReporter.read_from_metrics(metrics, pattern)
+                av_pod = self.opsview_reporter.read_from_metrics(metrics, pattern)
                 if av_pod:
                     av_pod = int(av_pod)
                     if av_pod <= self.critical_t:

--- a/aviso-server/monitoring/aviso_monitoring/reporter/aviso_auth_reporter.py
+++ b/aviso-server/monitoring/aviso_monitoring/reporter/aviso_auth_reporter.py
@@ -208,7 +208,7 @@ class PodAvailable(AvisoAuthChecker):
             logger.warning("Could not determine the pod's namespace.")
             namespace = "aviso"
 
-        pattern = rf'kube_deployment_status_replicas{{namespace="{namespace}",deployment="aviso-auth-\w+"}}'
+        pattern = rf'kube_deployment_status_replicas{{namespace="{namespace}",deployment="aviso-auth"}}'
         # defaults
         status = 0
         message = "All pods available"

--- a/aviso-server/monitoring/aviso_monitoring/reporter/aviso_rest_reporter.py
+++ b/aviso-server/monitoring/aviso_monitoring/reporter/aviso_rest_reporter.py
@@ -18,6 +18,8 @@ class AvisoRestReporter(OpsviewReporter):
         self.frequency = aviso_rest_config["frequency"]
         self.enabled = aviso_rest_config["enabled"]
         self.tlms = aviso_rest_config["tlms"]
+        #configure the metric vars once only here
+        OpsviewReporter.configure_metric_vars(config)
         super().__init__(config, *args, **kwargs)
 
     def process_messages(self):

--- a/aviso-server/monitoring/aviso_monitoring/reporter/aviso_rest_reporter.py
+++ b/aviso-server/monitoring/aviso_monitoring/reporter/aviso_rest_reporter.py
@@ -179,7 +179,6 @@ class PodAvailable(AvisoRestChecker):
         self.critical_t = kwargs["critical_t"]
         self.req_timeout = kwargs["req_timeout"]
         self.metric_server_url = kwargs["metric_server_url"]
-        self.opsview_reporter = OpsviewReporter()
         super().__init__(*args, **kwargs)
 
     def metric(self):
@@ -191,13 +190,13 @@ class PodAvailable(AvisoRestChecker):
 
         # fetch the cluster metrics
         if self.metric_server_url:
-            metrics = self.opsview_reporter.retrieve_metrics([self.metric_server_url], self.req_timeout)[
+            metrics = OpsviewReporter.retrieve_metrics([self.metric_server_url], self.req_timeout)[
                 self.metric_server_url
             ]
             if metrics:
                 logger.debug(f"Processing tlm {self.metric_name}...")
 
-                av_pod = self.opsview_reporter.read_from_metrics(metrics, pattern)
+                av_pod = OpsviewReporter.read_from_metrics(metrics, pattern)
                 if av_pod:
                     av_pod = int(av_pod)
                     if av_pod <= self.critical_t:

--- a/aviso-server/monitoring/aviso_monitoring/reporter/aviso_rest_reporter.py
+++ b/aviso-server/monitoring/aviso_monitoring/reporter/aviso_rest_reporter.py
@@ -185,9 +185,7 @@ class PodAvailable(AvisoRestChecker):
 
     def metric(self):
         namespace = self.get_k8s_pod_namespace()
-        if namespace:
-            logger.info(f"The pod is running in the '{namespace}' namespace.")
-        else:
+        if not namespace:
             logger.warning("Could not determine the pod's namespace.")
             namespace = "aviso"
 

--- a/aviso-server/monitoring/aviso_monitoring/reporter/aviso_rest_reporter.py
+++ b/aviso-server/monitoring/aviso_monitoring/reporter/aviso_rest_reporter.py
@@ -191,7 +191,7 @@ class PodAvailable(AvisoRestChecker):
             logger.warning("Could not determine the pod's namespace.")
             namespace = "aviso"
 
-        pattern = rf'kube_deployment_status_replicas{{namespace="{namespace}",deployment="aviso-rest-\w+"}}'
+        pattern = rf'kube_deployment_status_replicas{{namespace="{namespace}",deployment="aviso-rest"}}'
         # defaults
         status = 0
         message = "All pods available"

--- a/aviso-server/monitoring/aviso_monitoring/reporter/aviso_rest_reporter.py
+++ b/aviso-server/monitoring/aviso_monitoring/reporter/aviso_rest_reporter.py
@@ -18,7 +18,7 @@ class AvisoRestReporter(OpsviewReporter):
         self.frequency = aviso_rest_config["frequency"]
         self.enabled = aviso_rest_config["enabled"]
         self.tlms = aviso_rest_config["tlms"]
-        #configure the metric vars once only here
+        # configure the metric vars once only here
         OpsviewReporter.configure_metric_vars(config)
         super().__init__(config, *args, **kwargs)
 
@@ -184,7 +184,14 @@ class PodAvailable(AvisoRestChecker):
         super().__init__(*args, **kwargs)
 
     def metric(self):
-        pattern = r'kube_deployment_status_replicas{namespace="aviso",deployment="aviso-rest-\w+"}'
+        namespace = self.get_k8s_pod_namespace()
+        if namespace:
+            logger.info(f"The pod is running in the '{namespace}' namespace.")
+        else:
+            logger.warning("Could not determine the pod's namespace.")
+            namespace = "aviso"
+
+        pattern = rf'kube_deployment_status_replicas{{namespace="{namespace}",deployment="aviso-rest-\w+"}}'
         # defaults
         status = 0
         message = "All pods available"
@@ -226,3 +233,30 @@ class PodAvailable(AvisoRestChecker):
             m_status = {"name": self.metric_name, "status": 1, "message": "Metric could not be retrieved"}
         logger.debug(f"{self.metric_name} metric: {m_status}")
         return m_status
+
+    @staticmethod
+    def get_k8s_pod_namespace():
+        """
+        Retrieves the Kubernetes (k8s) namespace in which the current pod is running.
+
+        This function reads the namespace name from a file that Kubernetes automatically
+        mounts inside the pod. This file is typically located at:
+        '/var/run/secrets/kubernetes.io/serviceaccount/namespace'
+
+        Returns:
+            str: The namespace in which the pod is running. If the namespace cannot be determined
+                (e.g., the file doesn't exist or the pod is not running in a k8s environment),
+                the function returns None.
+        """
+        namespace_file = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+        try:
+            with open(namespace_file, "r") as file:
+                return file.read().strip()
+        except FileNotFoundError:
+            logger.error(f"Namespace file not found: {namespace_file}")
+        except IOError as e:
+            logger.error(f"I/O error occurred when reading namespace file: {e}")
+        except Exception as e:
+            logger.exception(f"Unexpected error occurred when reading namespace file: {e}")
+
+        return None

--- a/aviso-server/monitoring/aviso_monitoring/reporter/aviso_rest_reporter.py
+++ b/aviso-server/monitoring/aviso_monitoring/reporter/aviso_rest_reporter.py
@@ -179,6 +179,7 @@ class PodAvailable(AvisoRestChecker):
         self.critical_t = kwargs["critical_t"]
         self.req_timeout = kwargs["req_timeout"]
         self.metric_server_url = kwargs["metric_server_url"]
+        self.opsview_reporter = OpsviewReporter()
         super().__init__(*args, **kwargs)
 
     def metric(self):
@@ -190,13 +191,13 @@ class PodAvailable(AvisoRestChecker):
 
         # fetch the cluster metrics
         if self.metric_server_url:
-            metrics = OpsviewReporter.retrieve_metrics([self.metric_server_url], self.req_timeout)[
+            metrics = self.opsview_reporter.retrieve_metrics([self.metric_server_url], self.req_timeout)[
                 self.metric_server_url
             ]
             if metrics:
                 logger.debug(f"Processing tlm {self.metric_name}...")
 
-                av_pod = OpsviewReporter.read_from_metrics(metrics, pattern)
+                av_pod = self.opsview_reporter.read_from_metrics(metrics, pattern)
                 if av_pod:
                     av_pod = int(av_pod)
                     if av_pod <= self.critical_t:

--- a/aviso-server/monitoring/aviso_monitoring/reporter/etcd_reporter.py
+++ b/aviso-server/monitoring/aviso_monitoring/reporter/etcd_reporter.py
@@ -23,6 +23,7 @@ class EtcdReporter(OpsviewReporter):
         self.req_timeout = self.etcd_config["req_timeout"]
         self.member_urls = self.etcd_config["member_urls"]
         self.tlms = self.etcd_config["tlms"]
+        self.opsview_reporter = OpsviewReporter()
         super().__init__(config, *args, **kwargs)
 
     def process_messages(self):
@@ -33,7 +34,7 @@ class EtcdReporter(OpsviewReporter):
         logger.debug("Etcd processing metrics...")
 
         # fetch the raw tlms provided by etcd
-        raw_tlms = OpsviewReporter.retrieve_metrics(self.member_urls, self.req_timeout)  # noqa: F841
+        raw_tlms = self.opsview_reporter.retrieve_metrics(self.member_urls, self.req_timeout)  # noqa: F841
 
         # array of metric to return
         metrics = []

--- a/aviso-server/monitoring/aviso_monitoring/reporter/etcd_reporter.py
+++ b/aviso-server/monitoring/aviso_monitoring/reporter/etcd_reporter.py
@@ -23,7 +23,6 @@ class EtcdReporter(OpsviewReporter):
         self.req_timeout = self.etcd_config["req_timeout"]
         self.member_urls = self.etcd_config["member_urls"]
         self.tlms = self.etcd_config["tlms"]
-        self.opsview_reporter = OpsviewReporter()
         super().__init__(config, *args, **kwargs)
 
     def process_messages(self):
@@ -34,7 +33,7 @@ class EtcdReporter(OpsviewReporter):
         logger.debug("Etcd processing metrics...")
 
         # fetch the raw tlms provided by etcd
-        raw_tlms = self.opsview_reporter.retrieve_metrics(self.member_urls, self.req_timeout)  # noqa: F841
+        raw_tlms = OpsviewReporter.retrieve_metrics(self.member_urls, self.req_timeout)  # noqa: F841
 
         # array of metric to return
         metrics = []

--- a/aviso-server/monitoring/aviso_monitoring/reporter/opsview_reporter.py
+++ b/aviso-server/monitoring/aviso_monitoring/reporter/opsview_reporter.py
@@ -202,7 +202,8 @@ class OpsviewReporter(ABC):
         }
         return agg_tlm
 
-    def retrieve_metrics(self, metric_servers, req_timeout):
+    @classmethod
+    def retrieve_metrics(cls, metric_servers, req_timeout):
         """
         This methods retrieves the metrics provided by specific metric servers using a Prometheus interface.
         """
@@ -212,8 +213,8 @@ class OpsviewReporter(ABC):
             logger.debug(f"Retrieving metrics from {url}...")
             headers = {}
             try:
-                if self.metric_ssl_enabled:
-                    headers["Authorization"] = f"Bearer {self.metric_token}"
+                if cls.metric_ssl_enabled:
+                    headers["Authorization"] = f"Bearer {cls.metric_token}"
                 resp = requests.get(url, verify=False, timeout=req_timeout, headers=headers)
             except Exception as e:
                 logger.exception(f"Not able to get metrics from {url}, error {e}")

--- a/aviso-server/monitoring/aviso_monitoring/reporter/opsview_reporter.py
+++ b/aviso-server/monitoring/aviso_monitoring/reporter/opsview_reporter.py
@@ -19,14 +19,24 @@ from ..config import Config
 
 
 class OpsviewReporter(ABC):
+    metric_ssl_enabled = False
+    metric_token = ""
+
     def __init__(self, config: Config, msg_receiver=None):
         urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
         self.monitor_servers = config.monitor_servers
         self.msg_receiver = msg_receiver
         self.token = {}
+
+    @classmethod
+    def configure_metric_vars(cls, config):
+        """
+        Configures the class attributes based on the provided config.
+        """
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
         if config.kube_state_metrics["ssl_enabled"]:
-            self.metric_ssl_enabled = True
-            self.metric_token = config.kube_state_metrics["token"]
+            cls.metric_ssl_enabled = True
+            cls.metric_token = config.kube_state_metrics["token"]
 
     def ms_authenticate(self, m_server):
         """


### PR DESCRIPTION
With this pull request token support added for the kube-state-metrics connection. Also various refinements were introduced:

-  namespace were assumed to be aviso in the monitoring system, now namespace value is taken from the pods
-  token is taken from the config if available
-  opsview reporter is enhanced with ssl variables

As a note, with this commits, opsview is fully working again.