### PR TITLE
switch to ubuntu 20.04 for maintaining support for python 3.6

### DIFF
--- a/.github/workflows/check-publish.yml
+++ b/.github/workflows/check-publish.yml
@@ -4,7 +4,6 @@
 name: Check and publish
 
 on:
-
   workflow_dispatch: {}
 
   pull_request:
@@ -14,10 +13,9 @@ on:
     types: [created]
 
 jobs:
-
   quality:
     name: Code QA
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - run: pip install black flake8 isort
@@ -30,8 +28,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: ["ubuntu-latest"]
-        python-version: ["3.6", "3.7", "3.8", "3.9"]
+        platform: ["ubuntu-20.04", "macos-13"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
 
     name: Python ${{ matrix.python-version }} on ${{ matrix.platform }}
     runs-on: ${{ matrix.platform }}
@@ -86,27 +84,27 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.8'
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
 
-    - name: Check version
-      run: |
-        release=${GITHUB_REF##*/}
-        version=$(python setup.py --version)
-        test "$release" == "$version"
+      - name: Check version
+        run: |
+          release=${GITHUB_REF##*/}
+          version=$(python setup.py --version)
+          test "$release" == "$version"
 
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install setuptools wheel twine
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools wheel twine
 
-    - name: Build and publish
-      env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      run: |
-        python setup.py sdist bdist_wheel
-        twine upload dist/*
+      - name: Build and publish
+        env:
+          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: |
+          python setup.py sdist bdist_wheel
+          twine upload dist/*


### PR DESCRIPTION
Actually, this is 3 lines of change. It changes the ubuntu version, adds MacOS to the checks. 